### PR TITLE
Add unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
+  testMatch: ['**/__tests__/**/*.test.(js|jsx|ts|tsx)'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:cypress": "cross-env CYPRESS_SUPPORT=y yarn build",
     "start": "gatsby develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "test": "jest"
   },
   "dependencies": {
     "@lekoarts/gatsby-theme-cara": "^5.0.0",
@@ -25,6 +26,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "jest": "^29.0.0"
   }
 }

--- a/src/__tests__/date-for-weeks.test.js
+++ b/src/__tests__/date-for-weeks.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DateForWeeks from '../@lekoarts/gatsby-theme-cara/components/date-for-weeks';
+
+test('renders DateForWeeks component with default weeks', () => {
+  const { getByText } = render(<DateForWeeks />);
+  const linkElement = getByText(/04\/18\/2023/i);
+  expect(linkElement).toBeInTheDocument();
+});
+
+test('renders DateForWeeks component with specific weeks', () => {
+  const { getByText } = render(<DateForWeeks weeks={14} />);
+  const linkElement = getByText(/07\/25\/2023/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/__tests__/weeks-along.test.js
+++ b/src/__tests__/weeks-along.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import WeeksAlong from '../@lekoarts/gatsby-theme-cara/components/weeks-along';
+
+test('renders WeeksAlong component with default date', () => {
+  const { getByText } = render(<WeeksAlong />);
+  const linkElement = getByText(/weeks and/i);
+  expect(linkElement).toBeInTheDocument();
+});
+
+test('renders WeeksAlong component with specific date', () => {
+  const { getByText } = render(<WeeksAlong dateString="04/25/2023" />);
+  const linkElement = getByText(/weeks and/i);
+  expect(linkElement).toBeInTheDocument();
+});


### PR DESCRIPTION
Add unit tests for `WeeksAlong` and `DateForWeeks` components using Jest.

* **package.json**
  - Add Jest as a dev dependency.
  - Add a test script to run tests using Jest.

* **jest.config.js**
  - Add configuration for Jest.

* **src/__tests__/weeks-along.test.js**
  - Add unit tests for `WeeksAlong` component.

* **src/__tests__/date-for-weeks.test.js**
  - Add unit tests for `DateForWeeks` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rmw/pg?shareId=fd3f1c15-1ed6-4e53-bd31-4e8c4f854970).